### PR TITLE
small css fixes take card

### DIFF
--- a/src/js/pages/takes/TakeCard/Components/Comments.js
+++ b/src/js/pages/takes/TakeCard/Components/Comments.js
@@ -54,9 +54,10 @@ export default class TakeCardComments extends React.Component {
   render() {
     const {comments, deleteComment, txt} = this.props;
     const {width} = this.state;
+    const hasComments = comments.length!==0? true: false;
     return (
-      <Container innerRef={input => {this.myInput = input}}  >
-        <Comments>
+      <Container innerRef={input => {this.myInput = input;}} >
+        <Comments hasComments ={hasComments}>
           {
             comments.length!==0 ?
               comments.map((comment) => {
@@ -98,8 +99,9 @@ const Button = styled.button`
 `;
 
 const Comments = styled.div`
-height: 100px;
-overflow-y: auto;
+height: ${props => props.hasComments? '100px': '0px'};
+overflow-y: scroll;
+overflow-x: hidden;
 animation: ${fadeInAnimation} .5s ease-in;
 background: white;
 

--- a/src/languages/textToDisplay.json
+++ b/src/languages/textToDisplay.json
@@ -56,7 +56,7 @@
    "confirm": "Confirm",
    "alreadyPublished": "You can only have one publised take, UNPUBLISH first",
    "deleteTake": "Are you sure you want to delete this Take?",
-   "deletingTake": "Deleting Take..."
+   "deletingTake": "Deleting Take...",
    "deletingComment": "Deleting comment"
 
    },
@@ -117,7 +117,7 @@
      "confirm": "Confirmar",
      "alreadyPublished": "Solo puedes tener una grabación publicada a la vez, remueve la grabación publicada",
      "deleteTake": "Estás seguro que quieres borrar esta grabación?",
-     "deletingTake": "Borrando grabación"
+     "deletingTake": "Borrando grabación",
      "deletingComment": "Borrando Comentario"
 
    },


### PR DESCRIPTION
small css fixes to the comments in take card.

1) fix overflow-x on comments not allowing comment deletion
2) remove white space when no comments