### PR TITLE
add chunk navigation on chunktab

### DIFF
--- a/src/js/components/PlayerTracker.js
+++ b/src/js/components/PlayerTracker.js
@@ -207,4 +207,5 @@ const PlayIcon = styled.button`
   border-top: none;
   padding: 0.4vw;
   color: #969595
+  cursor: pointer;
 `;

--- a/src/js/pages/KanbanBoard/components/KanbanColumn.js
+++ b/src/js/pages/KanbanBoard/components/KanbanColumn.js
@@ -52,7 +52,6 @@ class KanbanColumn extends React.Component {
 
   }
 
-
   navigateToChapter(chapter_num, chapterId) {
 
     const {history, chapters} = this.props;

--- a/src/js/pages/KanbanBoard/components/UtilityPanel/ChunkPanel.js
+++ b/src/js/pages/KanbanBoard/components/UtilityPanel/ChunkPanel.js
@@ -4,9 +4,18 @@ import PlayerTracker from '../../../../components/PlayerTracker';
 
 
 class ChunkPanel extends Component {
+  constructor() {
+    super();
 
+    this.navigateChunk = this.navigateChunk.bind(this);
+  }
 
-render() {
+  navigateChunk(chunkId, chunkNum) {
+    this.props.getTakes(chunkId, chunkNum );
+  }
+
+  render() {
+    console.log(this.props, 'ALL MY CHUNK PANEL PROPS');
     const {selectedChunk, mode, txt} = this.props; //selectedChunk is the chunk number selected in the navbar, by default is 1
     return (
       <Container>
@@ -14,7 +23,7 @@ render() {
 
           return (
             <ChunksContainer selected= {selectedChunk == chk.startv} >
-              <label>{mode} {chk.startv} </label>
+              <label style={{cursor: 'pointer'}} onClick={()=> this.navigateChunk(chk.id, chk.startv)}>{mode} {chk.startv} </label>
               {chk.published_take != null ?
                 <PlayerTracker url={chk.published_take.location} />
                 :

--- a/src/js/pages/KanbanBoard/components/UtilityPanel/ChunkPanel.js
+++ b/src/js/pages/KanbanBoard/components/UtilityPanel/ChunkPanel.js
@@ -15,7 +15,6 @@ class ChunkPanel extends Component {
   }
 
   render() {
-    console.log(this.props, 'ALL MY CHUNK PANEL PROPS');
     const {selectedChunk, mode, txt} = this.props; //selectedChunk is the chunk number selected in the navbar, by default is 1
     return (
       <Container>

--- a/src/js/pages/KanbanBoard/components/UtilityPanel/UtilityPanel.js
+++ b/src/js/pages/KanbanBoard/components/UtilityPanel/UtilityPanel.js
@@ -37,7 +37,7 @@ export default class UtilityPanel extends React.Component {
     const {chapterId} = this.state;
     const { takes, chunkNum ,
       chunks, chapterComments, chunkComments, activeChunkId, saveComment,
-      uploadingComments, uploadError, resetError, txt, deleteComment} = this.props;
+      uploadingComments, uploadError, resetError, txt, deleteComment, getTakes} = this.props;
     let publishedTakeLocation =null;
     let mode = txt.chunk;
     const {search} = this.props.location;
@@ -105,12 +105,15 @@ export default class UtilityPanel extends React.Component {
 
             </CommentsPanel>
             :
-            <ChunkPanel txt={txt} mode={mode} takeLocation={publishedTakeLocation} selectedChunk={chunkNum} chunks={chunks} />
+            <ChunkPanel txt={txt} mode={mode} takeLocation={publishedTakeLocation}
+              selectedChunk={chunkNum} chunks={chunks}
+              activeChunkId={activeChunkId}
+              getTakes={getTakes} />
           }
         </UtilityPanelContainer>
         :
         <UtilityPanelNotVisible>
-          <Show onClick= {this.toggleUtilityPanel}> <i style={{fontSize:'2.0vw', paddingRight:'1vw'}} class="material-icons">arrow_back</i> </Show>
+          <Show onClick= {this.toggleUtilityPanel}> <i style={{fontSize: '2.0vw', paddingRight: '1vw'}} class="material-icons">arrow_back</i> </Show>
         </UtilityPanelNotVisible>
 
     );

--- a/src/js/pages/KanbanBoard/components/UtilityPanel/UtilityPanel.js
+++ b/src/js/pages/KanbanBoard/components/UtilityPanel/UtilityPanel.js
@@ -107,7 +107,6 @@ export default class UtilityPanel extends React.Component {
             :
             <ChunkPanel txt={txt} mode={mode} takeLocation={publishedTakeLocation}
               selectedChunk={chunkNum} chunks={chunks}
-              activeChunkId={activeChunkId}
               getTakes={getTakes} />
           }
         </UtilityPanelContainer>


### PR DESCRIPTION
1) Enable the user to navigate between chunks from the chunk tab of the utility panel
2) remove console.logs and unnecessary props 