### PR TITLE
Removed version label from psycopg2 package in requriements.txt

### DIFF
--- a/src/__test__/test_container/requirements.txt
+++ b/src/__test__/test_container/requirements.txt
@@ -7,7 +7,7 @@ django-cors-headers
 coreapi
 urllib3
 whitenoise
-psycopg2==2.7.3.2
+psycopg2
 django-jenkins
 coverage
 rest_social_auth


### PR DESCRIPTION
Removed version label from psycopg2 package in requirements.txt for docker container. The version was breaking the build. 