### PR TITLE
fix drag target overlaying next chunk/next chapter button

### DIFF
--- a/src/CustomDragLayer.js
+++ b/src/CustomDragLayer.js
@@ -8,7 +8,7 @@ import { DragLayer } from 'react-dnd';
 const layerStyles = {
   position: 'fixed',
   pointerEvents: 'none',
-  zIndex: 95,
+  zIndex: 101,
   left: 0,
   top: 0,
   width: '100%',

--- a/src/js/pages/KanbanBoard/components/KanbanColumn.js
+++ b/src/js/pages/KanbanBoard/components/KanbanColumn.js
@@ -355,6 +355,7 @@ const NextChunk = styled.button`
   	cursor: pointer;
   	outline:none;
     font-size: 1em + 1vw;
+    z-index: 99;
     i  {
       vertical-align: middle;
     }
@@ -370,6 +371,7 @@ padding: 0.75vw;
 cursor: pointer;
 outline:none;
 font-size: 1em + 1vw;
+z-index: 99;
 i  {
   vertical-align: middle;
 }
@@ -379,6 +381,7 @@ margin-top: 5px;
 NextChapter.displayName = 'NextChapter';
 
 const ChapterReview = styled(NextChapter)`
+  z-index: 99;
 `;
 ChapterReview.displayName = 'ChapterReview';
 

--- a/src/js/pages/KanbanBoard/components/ReviewDialog.js
+++ b/src/js/pages/KanbanBoard/components/ReviewDialog.js
@@ -78,7 +78,7 @@ const Container = styled.div`
   position: fixed;
   top:0;
   left:0;
-  z-index: 99;
+  z-index: 100;
 `;
 Container.displayName = 'Container';
 


### PR DESCRIPTION
fix next chapter/next verse button being overlaid by delete take drag target.

- this problem didn't allow the user to click on the next"..."  button when the screen got smaller or when the comments for the selected take was expanded